### PR TITLE
Warn if `with_them` is used before `where` is defined

### DIFF
--- a/lib/rspec/parameterized/core.rb
+++ b/lib/rspec/parameterized/core.rb
@@ -79,6 +79,8 @@ module RSpec
           @parameter ||= nil
 
           if @parameter.nil?
+            warn "#{b&.source_location&.join(':') || caller[0]}: `where` not defined."
+
             @parameterized_pending_cases ||= []
             @parameterized_pending_cases << [args, b]
           else


### PR DESCRIPTION
This PR emits a warning if `with_them` is used before `where` is defined.

See https://github.com/rspec-parameterized/rspec-parameterized-core/issues/8

## Impact

On this repository we are now seeing 3 warnings:

```
/home/peter/devel/rspec-parameterized-core/spec/rspec/parameterized/core_spec.rb:265: `where` not defined.
/home/peter/devel/rspec-parameterized-core/spec/rspec/parameterized/core_spec.rb:271: `where` not defined.
/home/peter/devel/rspec-parameterized-core/spec/rspec/parameterized/core_spec.rb:286: `where` not defined.
```

They relate to https://github.com/rspec-parameterized/rspec-parameterized-core/blob/94ed77992543f76d849805fd22f3fd38798b8f9d/spec/rspec/parameterized/core_spec.rb#L264-L304 which makes sense

However, emitting a warning in those cases would also cover the following case:

```ruby
describe 'empty' do
  where(:x) { [1] }

  describe 'another scope' do # !!! NOTE THIS EXTRA CONTEXT!!
    with_them do
      it 'works' do

      end
    end
  end
end

# 0 examples, 0 failures
```

### Full output

```shell
$ bundle exec rspec -f p --dry-run
warning: parser/current is loading parser/ruby30, which recognizes 3.0.6-compliant syntax, but you are running 3.0.5.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
/home/peter/devel/rspec-parameterized-core/spec/rspec/parameterized/core_spec.rb:265: `where` not defined.
/home/peter/devel/rspec-parameterized-core/spec/rspec/parameterized/core_spec.rb:271: `where` not defined.
/home/peter/devel/rspec-parameterized-core/spec/rspec/parameterized/core_spec.rb:286: `where` not defined.
Run options: include {:current=>true}

All examples were filtered out; ignoring {:current=>true}
......***..................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) RSpec::Parameterized where and with_them a: 1, b: 2, answer: 3 should do additions
     # PENDING
     # ./spec/rspec/parameterized/core_spec.rb:34

  2) RSpec::Parameterized where and with_them a: 5, b: 8, answer: 13 should do additions
     # PENDING
     # ./spec/rspec/parameterized/core_spec.rb:34

  3) RSpec::Parameterized where and with_them a: 0, b: 0, answer: 0 should do additions
     # PENDING
     # ./spec/rspec/parameterized/core_spec.rb:34


Deprecation Warnings:

RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.00623 seconds (files took 0.15319 seconds to load)
91 examples, 0 failures, 3 pending
```