### PR TITLE
Requires Ruby 2.7+

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'

--- a/rspec-parameterized-core.gemspec
+++ b/rspec-parameterized-core.gemspec
@@ -14,7 +14,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
 
   spec.homepage = "https://github.com/rspec-parameterized/rspec-parameterized-core"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
I want to add Prism gem as runtime dependency, but Prism gem requires Ruby 2.7+

https://rubygems.org/gems/prism/versions/1.4.0

```
Because every version of rspec-parameterized-core depends on prism >= 0
  and prism >= 0.22.0 depends on Ruby >= 2.7.0,
every version of rspec-parameterized-core requires Ruby >= 2.7.0 or prism >=
0, < 0.22.0.
And because prism < 0.22.0 depends on Ruby >= 3.0.0,
  every version of rspec-parameterized-core requires Ruby >= 2.7.0.
So, because Gemfile depends on rspec-parameterized-core >= 0
  and current Ruby version is = 2.6.10,
  version solving has failed.
```

https://github.com/rspec-parameterized/rspec-parameterized-core/actions/runs/14791209614/job/41528572607

So I dropped Ruby < 2.7

rer. #17, #18
