### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/rspec/parameterized/core/composite_parser.rb
+++ b/lib/rspec/parameterized/core/composite_parser.rb
@@ -25,7 +25,7 @@ module RSpec
         # @raise [RSpec::Parameterized::Core::ParserSyntaxError]
         def self.to_raw_source_with_parser(obj)
           obj.is_a?(Proc) ? obj.to_raw_source : obj.inspect
-        rescue Parser::SyntaxError => e
+        rescue Parser::SyntaxError
           raise ParserSyntaxError
         end
         private_class_method :to_raw_source_with_parser


### PR DESCRIPTION
Rescued exception is assigned to `e`, but it is never used. This leads to a warning:

```
lib/rspec/parameterized/core/composite_parser.rb:28: warning: assigned but unused variable - e
```