### PR TITLE
Fix massive object allocation in LazyArg#inspect

### DIFF
--- a/lib/rspec/parameterized/core/lazy_arg.rb
+++ b/lib/rspec/parameterized/core/lazy_arg.rb
@@ -11,9 +11,8 @@ module RSpec
         end
 
         def inspect
-          CompositeParser.to_raw_source(@block)
-        rescue ParserSyntaxError
-          super.inspect
+          filename, linenum = @block.source_location
+          "lazy { ... } (#{File.basename(filename)}:#{linenum})"
         end
       end
     end

--- a/spec/rspec/parameterized/core/lazy_arg_spec.rb
+++ b/spec/rspec/parameterized/core/lazy_arg_spec.rb
@@ -1,0 +1,9 @@
+describe RSpec::Parameterized::Core::LazyArg do
+  describe "#inspect" do
+    it "includes filename and line number" do
+      lazy_arg = RSpec::Parameterized::Core::LazyArg.new { 1 + 2 }; expected_line = __LINE__
+
+      expect(lazy_arg.inspect).to eq "lazy { ... } (lazy_arg_spec.rb:#{expected_line})"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Skip Prism parsing in `LazyArg#inspect` and use `source_location` instead.

When `lazy` blocks are inside array literals in `where` tables, the source line (ending with `}],`) is syntactically incomplete. This causes `parse_with_prism` to try adding lines one by one until EOF, with all parse attempts failing and allocating AST objects that become garbage immediately.

- Fixes #34